### PR TITLE
Remove a line from basics.md

### DIFF
--- a/chapters/basics.md
+++ b/chapters/basics.md
@@ -141,7 +141,6 @@ func main() {
 	fmt.Println(Greeting)
 	fmt.Println(Pi)
 	fmt.Println(Truth)
-	fmt.Println(Big)
 }
 ```
 


### PR DESCRIPTION
Line 144 was causing the following error when pasted directly into the playground
prog.go:17: constant 4611686018427387904 overflows int

I've removed it to closer match what the actual playground link is demonstrating.
